### PR TITLE
added promise.all to prevent race conditions and to improve performance

### DIFF
--- a/src/testportal/index.ts
+++ b/src/testportal/index.ts
@@ -70,15 +70,15 @@ export async function* getQuestions(
   await page.setDefaultNavigationTimeout(0);
   await page.goto(testURL.url.href, { waitUntil: 'networkidle0' });
   await fillForm(page);
-  await submitForm(page);
-  await page.waitForNavigation({ waitUntil: 'load' });
-
+  await Promise.all([
+    submitForm(page),
+    page.waitForNavigation({ waitUntil: 'load' })
+  ])
   const questions = await page.$eval('.question_header_content', (el) => el.textContent);
   if(!questions) throw new Error("There was an error with retrieving questions amount data");
   const questionsAmount = parseInt(questions.slice(10));
 
   for (let i = 0; i < questionsAmount; i++) {
-    if (i != 0) await page.waitForNavigation({ waitUntil: 'networkidle2' });
     const totalWidth = await page.evaluate(
       () => document.documentElement.offsetWidth
     );
@@ -97,7 +97,10 @@ export async function* getQuestions(
       testID: testURL.testID,
       question: i + 1,
     };
-    await submitAnswer(page);
+    await Promise.all([
+      submitAnswer(page),
+      page.waitForNavigation({ waitUntil: 'networkidle2' })
+    ])
   }
   console.log(`Completed test TestID: ${testURL.testID}`);
   await browser.close();


### PR DESCRIPTION
The bot was running very slowly in my case + it wasn't posting some screenshots. After adding promise.all, it all ran butter smooth and as far as i know it also prevents a race condition.

Based on:
https://stackoverflow.com/questions/46948489/puppeteer-wait-page-load-after-form-submit